### PR TITLE
Fix orientation of theme toggle icons

### DIFF
--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -23,9 +23,9 @@ export function ThemeToggle() {
             className="rounded-md p-2 hover:bg-accent transition-colors"
         >
             {theme === "dark" ? (
-                <Sun className="h-4 w-4 text-foreground rotate-0 scale-100 transition-all dark:-rotate-90" />
+                <Sun className="h-4 w-4 text-foreground transition-all" />
             ) : (
-                <Moon className="h-4 w-4 text-foreground rotate-0 scale-100 transition-all dark:rotate-90" />
+                <Moon className="h-4 w-4 text-foreground transition-all" />
             )}
             <span className="sr-only">Toggle theme</span>
         </button>


### PR DESCRIPTION
## Summary
- keep theme icons upright to avoid unexpected rotation on page load

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840b6f46cc8832c87dfc2b02bb59ef7