### PR TITLE
Fix immediate theme toggling

### DIFF
--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -5,7 +5,7 @@ import { Moon, Sun } from "lucide-react"
 import { useTheme } from "next-themes"
 
 export function ThemeToggle() {
-    const { theme, setTheme } = useTheme()
+    const { resolvedTheme, setTheme } = useTheme()
     const [mounted, setMounted] = React.useState(false)
 
     // useEffect only runs on the client, so now we can safely show the UI
@@ -19,10 +19,10 @@ export function ThemeToggle() {
 
     return (
         <button
-            onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+            onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
             className="rounded-md p-2 hover:bg-accent transition-colors"
         >
-            {theme === "dark" ? (
+            {resolvedTheme === "dark" ? (
                 <Sun className="h-4 w-4 text-foreground rotate-0 scale-100 transition-all dark:-rotate-90" />
             ) : (
                 <Moon className="h-4 w-4 text-foreground rotate-0 scale-100 transition-all dark:rotate-90" />

--- a/src/components/ui/dock.tsx
+++ b/src/components/ui/dock.tsx
@@ -47,7 +47,7 @@ const Dock = React.forwardRef<HTMLDivElement, DockProps>(
         onMouseMove={(e) => mouseX.set(e.pageX)}
         onMouseLeave={() => mouseX.set(Infinity)}
         {...props}
-        className={cn(dockVariants({ className }))}
+        className={cn(dockVariants(), className)}
       >
         {renderChildren()}
       </motion.div>


### PR DESCRIPTION
## Summary
- fix ThemeToggle to reference resolvedTheme instead of theme so the theme switches on the first click

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Instrument Serif` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6840b32e9794832cab1ed54fb22be7a8